### PR TITLE
docs: Sync TRACEPOINT HOOK v1.1

### DIFF
--- a/docs/zh/guide/tracepoint-hook.md
+++ b/docs/zh/guide/tracepoint-hook.md
@@ -46,7 +46,7 @@
  		.ptr.compat = __envp,
  	};
 +#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+    trace_ksu_trace_execveat_sucompat_hook((int *)AT_FDCWD, &filename, NULL, NULL, NULL); /* 32-bit su */
++    trace_ksu_trace_execveat_hook((int *)AT_FDCWD, &filename, &argv, &envp, 0)); // 32-bit su and 32-on-64 support
 +#endif
  	return do_execveat_common(AT_FDCWD, filename, argv, envp, 0);
  }
@@ -232,35 +232,4 @@
  	if (is_event_supported(type, dev->evbit, EV_MAX)) {
 
  		spin_lock_irqsave(&dev->event_lock, flags);
-```
-
-## pm 命令执行失败？
-
-你需要修改 `drivers/tty/pty.c`
-
-```diff
---- a/drivers/tty/pty.c
-+++ b/drivers/tty/pty.c
-@@ -31,6 +31,10 @@
- #include <linux/compat.h>
- #include "tty.h"
-
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+#include <../../drivers/kernelsu/ksu_trace.h>
-+#endif
-+
- #undef TTY_DEBUG_HANGUP
- #ifdef TTY_DEBUG_HANGUP
- # define tty_debug_hangup(tty, f, args...)	tty_debug(tty, f, ##args)
-@@ -707,6 +711,10 @@ static struct tty_struct *pts_unix98_lookup(struct tty_driver *driver,
- {
- 	struct tty_struct *tty;
-
-+#if defined(CONFIG_KSU) && defined(CONFIG_KSU_TRACEPOINT_HOOK)
-+		trace_ksu_trace_devpts_hook((struct inode *)file->f_path.dentry->d_inode);
-+#endif
-+
- 	mutex_lock(&devpts_mutex);
- 	tty = devpts_get_priv(file->f_path.dentry);
- 	mutex_unlock(&devpts_mutex);
 ```


### PR DESCRIPTION
- Remove devpts hook section
- Replace trace_ksu_trace_execveat_sucompat_hook with trace_ksu_trace_execveat_hook for 32-bit and 32-on-64 support
- Drop outdated pm command fix instructions

Link: https://github.com/SukiSU-Ultra/SukiSU-Ultra/commit/f1f7c61aeea8357c583f68558801185cba8f1cdd